### PR TITLE
show error messages instead of failing silently

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -51,7 +51,7 @@ const genericErrorHandler = (err, req, res, next) => {
   res.status(statusCode)
   return res.send({
     status: statusCode,
-    error: err,
+    error: err.message,
   })
 }
 


### PR DESCRIPTION
Previously, if the API server threw an error, the error messages would not be shown in console. This would make it difficult to see where and why snakes were not behaving as intended, particularly when the errors were only in certain code paths or where the errors were not fatal during mid-game.

This change logs errors to console.