### PR TITLE
DEV-193 use 'server' header to identify project

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,10 @@ const { info, start, move, end } = require('./logic')
 
 const app = express()
 app.use(express.json())
+app.use(function (req, res, next) {
+    res.set("Server", "BattlesnakeOfficial/starter-snake-javascript")
+    next()
+})
 
 const port = process.env.PORT || 8080
 


### PR DESCRIPTION
Updates the starter project to identify itself in responses using the `Server` header